### PR TITLE
Add multiple-symbol imports

### DIFF
--- a/quark-go/src/parser/QuarkParser.g4
+++ b/quark-go/src/parser/QuarkParser.g4
@@ -14,6 +14,7 @@ decl
 importdecl
     : KW_IMPORT name SEMI # SingleImport
     | KW_IMPORT name DOT OP_MUL SEMI #WildcardImport
+    | KW_IMPORT name DOT LPAREN realname (COMMA realname)+ RPAREN SEMI #MultiImport
     ;
 
 block: stmt*;

--- a/quark-go/src/parser/parse_tree_converter.go
+++ b/quark-go/src/parser/parse_tree_converter.go
@@ -169,15 +169,40 @@ func (ptc *ParseTreeConverter) visitDecl(rawDecl IDeclContext) quark.Decl {
 func (ptc *ParseTreeConverter) VisitSingleImport(ctx *SingleImportContext) interface{} {
 	println("visiting single import")
 	quarkName := ptc.Visit(ctx.Name()).(quark.Name)
+	kwImport := ptc.terminalPosition(ctx.KW_IMPORT())
 	return &quark.SingleImport{
-		GenericImport: quark.GenericImport{PackageName:quarkName},
+		GenericImport: quark.GenericImport{
+			PackageName:quarkName,
+			KwImport: kwImport,
+		},
 	}
 }
 
 func (ptc *ParseTreeConverter) VisitWildcardImport(ctx *WildcardImportContext) interface{} {
 	quarkName := ptc.Visit(ctx.Name()).(quark.Name)
+	kwImport := ptc.terminalPosition(ctx.KW_IMPORT())
 	return &quark.WildcardImport{
-		GenericImport: quark.GenericImport{PackageName:quarkName},
+		GenericImport: quark.GenericImport{
+			PackageName:quarkName,
+			KwImport: kwImport,
+		},
+	}
+}
+
+func (ptc *ParseTreeConverter) VisitMultiImport(ctx *MultiImportContext) interface{} {
+	packageName := ptc.visitName(ctx.Name())
+	kwImport := ptc.terminalPosition(ctx.KW_IMPORT())
+	symbols := make([]*quark.RealName, len(ctx.AllRealname()))
+	for i, node := range ctx.AllRealname() {
+		symbols[i] = ptc.visitRealname(node)
+	}
+	return &quark.MultiImport{
+		GenericImport: quark.GenericImport{
+			PackageName:packageName,
+			KwImport: kwImport,
+		},
+		Symbols:       nil,
+		CloseParen:    quark.ObjectPosition{},
 	}
 }
 

--- a/quark-go/src/parser/parser_test_data.yml
+++ b/quark-go/src/parser/parser_test_data.yml
@@ -55,3 +55,11 @@ cases:
         return a;
       }
     expect: valid
+
+  - case: import-decls
+    note: Tests the three different kinds of imports
+    quark: |
+      import foo.bar.*;
+      import another.thing;
+      import some.(more, things, i, guess);
+    expect: valid

--- a/quark-go/src/quark/importdecl.go
+++ b/quark-go/src/quark/importdecl.go
@@ -4,7 +4,7 @@ type (
 	GenericImport struct {
 		PackageName Name
 
-		kwImport ObjectPosition
+		KwImport ObjectPosition
 	}
 
 	SingleImport struct {
@@ -16,10 +16,16 @@ type (
 
 		star ObjectPosition
 	}
+
+	MultiImport struct {
+		GenericImport
+		Symbols []*RealName
+		CloseParen ObjectPosition
+	}
 )
 
 func (i *GenericImport) Start() *ObjectPosition {
-	return &i.kwImport
+	return &i.KwImport
 }
 
 func (i *GenericImport) End() *ObjectPosition {
@@ -28,6 +34,10 @@ func (i *GenericImport) End() *ObjectPosition {
 
 func (w *WildcardImport) End() *ObjectPosition {
 	return w.star.Next()
+}
+
+func (m *MultiImport) End() *ObjectPosition {
+	return m.CloseParen.Next()
 }
 
 func (i *GenericImport) importDeclNode() {}


### PR DESCRIPTION
It is now possible to import multiple symbols from the same file on one line.

The following test case is added:
```
import foo.bar.*;
import another.thing;
import some.(more, things, i, guess);
```