### PR TITLE
Add an API for walking the AST

### DIFF
--- a/src/quark/array.go
+++ b/src/quark/array.go
@@ -12,7 +12,7 @@ type (
 		closeBrace ObjectPosition
 	}
 
-	//An array index. Can appear as expression or assignable.
+//An array index. Can appear as expression or assignable.
 	ArrayIndex struct {
 		ArrayExpr Expr
 		Indices   []Expr
@@ -61,4 +61,36 @@ func (e *ArrayIndex) Start() *ObjectPosition {
 
 func (e *ArrayIndex) End() *ObjectPosition {
 	return e.closeBrace.Next()
+}
+
+//Accept impls
+
+func (e *Slice) Accept(v Visitor) {
+	if v.Visit(e) == nil {
+		return
+	}
+
+	e.ArrayExpr.Accept(v)
+
+	if e.Msb != nil {
+		e.Msb.Accept(v)
+	}
+	if e.Lsb != nil {
+		e.Lsb.Accept(v)
+	}
+	if e.Step != nil {
+		e.Step.Accept(v)
+	}
+}
+
+func (e *ArrayIndex) Accept(v Visitor) {
+	if v.Visit(e) == nil {
+		return
+	}
+
+	e.ArrayExpr.Accept(v)
+
+	for _, index := range e.Indices {
+		index.Accept(v)
+	}
 }

--- a/src/quark/assignable.go
+++ b/src/quark/assignable.go
@@ -67,3 +67,31 @@ func (a *TupleDestructionAssignment) End() *ObjectPosition {
 func (a *ValueAssignment) assignableNode() {}
 func (a *VariableDefinitionAssignable) assignableNode() {}
 func (a *TupleDestructionAssignment) assignableNode() {}
+
+//Accept impls
+func (a *ValueAssignment) Accept(v Visitor) {
+	if v.Visit(a) == nil {
+		return
+	}
+
+	a.Variable.Accept(v)
+}
+
+func (a *VariableDefinitionAssignable) Accept(v Visitor) {
+	if v.Visit(a) == nil {
+		return
+	}
+
+	a.VarName.Accept(v)
+	a.VarType.Accept(v)
+}
+
+func (a *TupleDestructionAssignment) Accept(v Visitor) {
+	if v.Visit(a) == nil {
+		return
+	}
+
+	for _, assignable := range a.Assignables {
+		assignable.Accept(v)
+	}
+}

--- a/src/quark/branch.go
+++ b/src/quark/branch.go
@@ -79,3 +79,21 @@ func (b *MatchBranch) End() *ObjectPosition {
 
 func (b *IfBranch) branchNode() {}
 func (b *MatchBranch) branchNode() {}
+
+
+//Accept impls
+
+func (b *IfBranch) Accept(v Visitor) { //TODO: Branch parts need to be proper AST nodes (see GH-40)
+	if v.Visit(b) == nil {
+		return
+	}
+}
+
+func (b *MatchBranch) Accept(v Visitor) { //TODO: GH-40
+	if v.Visit(b) == nil {
+		return
+	}
+
+	b.MatchExpr.Accept(v)
+
+}

--- a/src/quark/clock.go
+++ b/src/quark/clock.go
@@ -13,3 +13,11 @@ func (c *AtomicClock) End() *ObjectPosition {
 }
 
 func (c *AtomicClock) clockExprNode() {}
+
+func (c *AtomicClock) Accept(v Visitor) {
+	if v.Visit(c) == nil {
+		return
+	}
+
+	c.ClockName.Accept(v)
+}

--- a/src/quark/decl.go
+++ b/src/quark/decl.go
@@ -88,3 +88,70 @@ func (s *ModuleDecl) End() *ObjectPosition {
 func (s *StructDecl) declNode() {}
 func (s *FunctionDecl) declNode() {}
 func (s *ModuleDecl) declNode() {}
+
+//Accept impls
+
+func (s *StructDecl) Accept(v Visitor) {
+	if v.Visit(s) != nil {
+		return
+	}
+
+	s.StructName.Accept(v)
+	for _, params := range s.Parameters {
+		params.Accept(v)
+	}
+
+	for _, trait := range s.TraitImpls {
+		trait.Accept(v)
+	}
+
+	for _, field := range s.Fields {
+		field.Accept(v)
+	}
+}
+
+func (s *FunctionDecl) Accept(v Visitor) {
+	if v.Visit(s) != nil {
+		return
+	}
+
+	s.SymbolName.Accept(v)
+	for _, param := range s.Parameters {
+		param.Accept(v)
+	}
+
+	for _, arg := range s.Arguments {
+		arg.Accept(v)
+	}
+
+	if s.Returns != nil {
+		s.Returns.Accept(v)
+	}
+
+	for _, stmt := range s.Body {
+		stmt.Accept(v)
+	}
+}
+
+func (s *ModuleDecl) Accept(v Visitor) {
+	if v.Visit(s) != nil {
+		return
+	}
+
+	s.SymbolName.Accept(v)
+	for _, param := range s.Parameters {
+		param.Accept(v)
+	}
+
+	for _, arg := range s.Arguments {
+		arg.Accept(v)
+	}
+
+	if s.Returns != nil {
+		s.Returns.Accept(v)
+	}
+
+	for _, stmt := range s.Body {
+		stmt.Accept(v)
+	}
+}

--- a/src/quark/expr.go
+++ b/src/quark/expr.go
@@ -438,34 +438,154 @@ func (e *LiteralExpr) Accept(v Visitor) {
 	if v.Visit(e) != nil {
 		return
 	}
+
+	e.Value.Accept(v)
 }
 
 func (e *VarExpr) Accept(v Visitor) {
 	if v.Visit(e) != nil {
 		return
 	}
+
+	e.VarName.Accept(v)
 }
 
 func (e *FieldExpr) Accept(v Visitor) {
 	if v.Visit(e) != nil {
 		return
 	}
+
+	e.Selectable.Accept(v)
+	e.FieldName.Accept(v)
 }
 
 func (e *ParensExpr) Accept(v Visitor) {
 	if v.Visit(e) != nil {
 		return
 	}
+
+	e.SubExpr.Accept(v)
 }
 
 func (e *TupleExpr) Accept(v Visitor) {
 	if v.Visit(e) != nil {
 		return
 	}
+
+	for _, expr := range e.Exprs {
+		expr.Accept(v)
+	}
 }
 
-func (e *LiteralExpr) Accept(v Visitor) {
+func (e *ConstructorExpr) Accept(v Visitor) {
 	if v.Visit(e) != nil {
 		return
 	}
+
+	for _, assignments := range e.FieldAssignments {
+		assignments.Accept(v)
+	}
+}
+
+func (e *NewModuleExpr) Accept(v Visitor) {
+	if v.Visit(e) != nil {
+		return
+	}
+
+	e.ModuleType.Accept(v)
+	for _, arg := range e.Arguments {
+		arg.Accept(v)
+	}
+}
+
+func (e *FunctionCall) Accept(v Visitor) {
+	if v.Visit(e) != nil {
+		return
+	}
+
+	e.FunctionExpr.Accept(v)
+	for _, arg := range e.Arguments {
+		arg.Accept(v)
+	}
+}
+
+func (e *LambdaExpr) Accept(v Visitor) {
+	if v.Visit(e) != nil {
+		return
+	}
+
+	for _, arg := range e.Arguments {
+		arg.Accept(v)
+	}
+
+	for _, stmt := range e.Body {
+		stmt.Accept(v)
+	}
+
+	if e.FinalExpr != nil {
+		e.FinalExpr.Accept(v)
+	}
+}
+
+func (e *UnOp) Accept(v Visitor) {
+	if v.Visit(e) != nil {
+		return
+	}
+
+	e.Expr.Accept(v)
+}
+
+func (e *ConcatExpr) Accept(v Visitor) {
+	if v.Visit(e) != nil {
+		return
+	}
+
+	for _, piece := range e.ConcatPieces {
+		piece.Accept(v)
+	}
+}
+
+func (e *BinOp) Accept(v Visitor) {
+	if v.Visit(e) != nil {
+		return
+	}
+
+	e.Left.Accept(v)
+	e.Right.Accept(v)
+}
+
+func (e *TernaryExpr) Accept(v Visitor) {
+	if v.Visit(e) != nil {
+		return
+	}
+
+	e.IfExpr.Accept(v)
+	e.Cond.Accept(v)
+	e.ElseExpr.Accept(v)
+}
+
+func (e *BranchExpr) Accept(v Visitor) {
+	if v.Visit(e) != nil {
+		return
+	}
+
+	e.X.Accept(v)
+}
+
+func (e *ArrayLiteralExpr) Accept(v Visitor) {
+	if v.Visit(e) != nil {
+		return
+	}
+
+	for _, value := range e.Values {
+		value.Accept(v)
+	}
+}
+
+func (e *ClockToExpr) Accept(v Visitor) {
+	if v.Visit(e) != nil {
+		return
+	}
+
+	e.Clock.Accept(v)
 }

--- a/src/quark/expr.go
+++ b/src/quark/expr.go
@@ -432,3 +432,40 @@ func (e ClockToExpr) Start() *ObjectPosition {
 func (e ClockToExpr) End() *ObjectPosition {
 	return e.closeParen.Next()
 }
+
+//Accept impl
+func (e *LiteralExpr) Accept(v Visitor) {
+	if v.Visit(e) != nil {
+		return
+	}
+}
+
+func (e *VarExpr) Accept(v Visitor) {
+	if v.Visit(e) != nil {
+		return
+	}
+}
+
+func (e *FieldExpr) Accept(v Visitor) {
+	if v.Visit(e) != nil {
+		return
+	}
+}
+
+func (e *ParensExpr) Accept(v Visitor) {
+	if v.Visit(e) != nil {
+		return
+	}
+}
+
+func (e *TupleExpr) Accept(v Visitor) {
+	if v.Visit(e) != nil {
+		return
+	}
+}
+
+func (e *LiteralExpr) Accept(v Visitor) {
+	if v.Visit(e) != nil {
+		return
+	}
+}

--- a/src/quark/expr.go
+++ b/src/quark/expr.go
@@ -435,7 +435,7 @@ func (e ClockToExpr) End() *ObjectPosition {
 
 //Accept impl
 func (e *LiteralExpr) Accept(v Visitor) {
-	if v.Visit(e) != nil {
+	if v.Visit(e) == nil {
 		return
 	}
 
@@ -443,7 +443,7 @@ func (e *LiteralExpr) Accept(v Visitor) {
 }
 
 func (e *VarExpr) Accept(v Visitor) {
-	if v.Visit(e) != nil {
+	if v.Visit(e) == nil {
 		return
 	}
 
@@ -451,7 +451,7 @@ func (e *VarExpr) Accept(v Visitor) {
 }
 
 func (e *FieldExpr) Accept(v Visitor) {
-	if v.Visit(e) != nil {
+	if v.Visit(e) == nil {
 		return
 	}
 
@@ -460,7 +460,7 @@ func (e *FieldExpr) Accept(v Visitor) {
 }
 
 func (e *ParensExpr) Accept(v Visitor) {
-	if v.Visit(e) != nil {
+	if v.Visit(e) == nil {
 		return
 	}
 
@@ -468,7 +468,7 @@ func (e *ParensExpr) Accept(v Visitor) {
 }
 
 func (e *TupleExpr) Accept(v Visitor) {
-	if v.Visit(e) != nil {
+	if v.Visit(e) == nil {
 		return
 	}
 
@@ -478,7 +478,7 @@ func (e *TupleExpr) Accept(v Visitor) {
 }
 
 func (e *ConstructorExpr) Accept(v Visitor) {
-	if v.Visit(e) != nil {
+	if v.Visit(e) == nil {
 		return
 	}
 
@@ -488,7 +488,7 @@ func (e *ConstructorExpr) Accept(v Visitor) {
 }
 
 func (e *NewModuleExpr) Accept(v Visitor) {
-	if v.Visit(e) != nil {
+	if v.Visit(e) == nil {
 		return
 	}
 
@@ -499,7 +499,7 @@ func (e *NewModuleExpr) Accept(v Visitor) {
 }
 
 func (e *FunctionCall) Accept(v Visitor) {
-	if v.Visit(e) != nil {
+	if v.Visit(e) == nil {
 		return
 	}
 
@@ -510,7 +510,7 @@ func (e *FunctionCall) Accept(v Visitor) {
 }
 
 func (e *LambdaExpr) Accept(v Visitor) {
-	if v.Visit(e) != nil {
+	if v.Visit(e) == nil {
 		return
 	}
 
@@ -528,7 +528,7 @@ func (e *LambdaExpr) Accept(v Visitor) {
 }
 
 func (e *UnOp) Accept(v Visitor) {
-	if v.Visit(e) != nil {
+	if v.Visit(e) == nil {
 		return
 	}
 
@@ -536,7 +536,7 @@ func (e *UnOp) Accept(v Visitor) {
 }
 
 func (e *ConcatExpr) Accept(v Visitor) {
-	if v.Visit(e) != nil {
+	if v.Visit(e) == nil {
 		return
 	}
 
@@ -546,7 +546,7 @@ func (e *ConcatExpr) Accept(v Visitor) {
 }
 
 func (e *BinOp) Accept(v Visitor) {
-	if v.Visit(e) != nil {
+	if v.Visit(e) == nil {
 		return
 	}
 
@@ -555,7 +555,7 @@ func (e *BinOp) Accept(v Visitor) {
 }
 
 func (e *TernaryExpr) Accept(v Visitor) {
-	if v.Visit(e) != nil {
+	if v.Visit(e) == nil {
 		return
 	}
 
@@ -565,7 +565,7 @@ func (e *TernaryExpr) Accept(v Visitor) {
 }
 
 func (e *BranchExpr) Accept(v Visitor) {
-	if v.Visit(e) != nil {
+	if v.Visit(e) == nil {
 		return
 	}
 
@@ -573,7 +573,7 @@ func (e *BranchExpr) Accept(v Visitor) {
 }
 
 func (e *ArrayLiteralExpr) Accept(v Visitor) {
-	if v.Visit(e) != nil {
+	if v.Visit(e) == nil {
 		return
 	}
 
@@ -583,7 +583,7 @@ func (e *ArrayLiteralExpr) Accept(v Visitor) {
 }
 
 func (e *ClockToExpr) Accept(v Visitor) {
-	if v.Visit(e) != nil {
+	if v.Visit(e) == nil {
 		return
 	}
 

--- a/src/quark/importdecl.go
+++ b/src/quark/importdecl.go
@@ -41,3 +41,31 @@ func (m *MultiImport) End() *ObjectPosition {
 }
 
 func (i *GenericImport) importDeclNode() {}
+
+func (i *SingleImport) Accept(v Visitor) {
+	if v.Visit(i) == nil {
+		return
+	}
+
+	i.PackageName.Accept(v)
+}
+
+func (w *WildcardImport) Accept(v Visitor) {
+	if v.Visit(w) == nil {
+		return
+	}
+
+	w.PackageName.Accept(v)
+}
+
+func (m *MultiImport) Accept(v Visitor) {
+	if v.Visit(m) == nil {
+		return
+	}
+
+	m.PackageName.Accept(v)
+
+	for _, symbol := range m.Symbols {
+		symbol.Accept(v)
+	}
+}

--- a/src/quark/inner_concat.go
+++ b/src/quark/inner_concat.go
@@ -34,3 +34,22 @@ func (r ReplicateConcat) Start() *ObjectPosition {
 func (r ReplicateConcat) End() *ObjectPosition {
 	return r.rCurly.Next()
 }
+
+
+//Accept impls
+func (a *AtomicInnerConcat) Accept(v Visitor) {
+	if v.Visit(a) == nil {
+		return
+	}
+
+	a.X.Accept(v)
+}
+
+func (r *ReplicateConcat) Accept(v Visitor) {
+	if v.Visit(r) == nil {
+		return
+	}
+
+	r.ReplicateAmount.Accept(v)
+	r.ReplicateExpr.Accept(v)
+}

--- a/src/quark/name.go
+++ b/src/quark/name.go
@@ -40,3 +40,18 @@ func (n *QualifiedName) End() *ObjectPosition {
 
 func (n *RealName) nameNode() {}
 func (n *QualifiedName) nameNode() {}
+
+//Accept impls
+func (n *RealName) Accept(v Visitor) {
+	v.Visit(n)
+}
+
+func (n *QualifiedName) Accept(v Visitor) {
+	if v.Visit(n) != nil {
+		return
+	}
+
+	for _, name := range n.Parts {
+		name.Accept(v)
+	}
+}

--- a/src/quark/other.go
+++ b/src/quark/other.go
@@ -43,3 +43,25 @@ func (c *CallArgument) End() *ObjectPosition {
 }
 
 
+//Accept impl
+func (f *Field) Accept(v Visitor) {
+	if v.Visit(f) == nil {
+		return
+	}
+
+	f.FieldType.Accept(v)
+	f.FieldName.Accept(v)
+}
+
+func (c *CallArgument) Accept(v Visitor) {
+	if v.Visit(c) == nil {
+		return
+	}
+
+	if c.FieldName != nil {
+		c.FieldName.Accept(v)
+	}
+
+	c.ValueExpr.Accept(v)
+}
+

--- a/src/quark/returnlist.go
+++ b/src/quark/returnlist.go
@@ -34,6 +34,10 @@ func (r *NamedReturn) Start() *ObjectPosition {
 	return &r.openParen
 }
 
+func (o OneNamedReturn) Start() *ObjectPosition {
+	return o.ReturnType.Start()
+}
+
 func (r *SingleReturn) End() *ObjectPosition {
 	return r.ReturnType.End()
 }
@@ -42,5 +46,40 @@ func (r *NamedReturn) End() *ObjectPosition {
 	return &r.closeParen
 }
 
+func (o OneNamedReturn) End() *ObjectPosition {
+	return o.ReturnName.End()
+}
+
+
+
+func (o OneNamedReturn) returnListNode() {}
 func (r *SingleReturn) returnListNode() {}
 func (r *NamedReturn) returnListNode() {}
+
+
+func (r *SingleReturn) Accept(v Visitor) {
+	if v.Visit(r) == nil {
+		return
+	}
+
+	r.ReturnType.Accept(v)
+}
+
+func (r *NamedReturn) Accept(v Visitor) {
+	if v.Visit(r) == nil {
+		return
+	}
+
+	for _, item := range r.ReturnTypes {
+		item.Accept(v)
+	}
+}
+
+func (o OneNamedReturn) Accept(v Visitor) {
+	if v.Visit(o) == nil {
+		return
+	}
+
+	o.ReturnType.Accept(v)
+	o.ReturnName.Accept(v)
+}

--- a/src/quark/stmt.go
+++ b/src/quark/stmt.go
@@ -129,3 +129,59 @@ func (s *DeclarationStmt) stmtNode() {}
 func (s *BranchStmt) stmtNode() {}
 func (s *FutureStmt) stmtNode() {}
 func (s *ReturnStmt) stmtNode() {}
+
+func (s *AssignStmt) Accept(v Visitor) {
+	if v.Visit(s) == nil {
+		return
+	}
+
+	s.AssignTo.Accept(v)
+	s.TheExpr.Accept(v)
+}
+
+func (s *RegAssignStmt) Accept(v Visitor) {
+	if v.Visit(s) == nil {
+		return
+	}
+
+	s.Clock.Accept(v)
+	if s.Reset != nil {
+		s.Reset.Accept(v)
+	}
+
+	s.AssignTo.Accept(v)
+	s.TheExpr.Accept(v)
+}
+
+func (s *DeclarationStmt) Accept(v Visitor) {
+	if v.Visit(s) == nil {
+		return
+	}
+
+	s.Declaration.Accept(v)
+}
+
+func (s *BranchStmt) Accept(v Visitor) {
+	if v.Visit(s) == nil {
+		return
+	}
+
+	s.TheBranch.Accept(v)
+}
+
+func (s *FutureStmt) Accept(v Visitor) {
+	if v.Visit(s) == nil {
+		return
+	}
+
+	s.FutureType.Accept(v)
+	s.FutureName.Accept(v)
+}
+
+func (s *ReturnStmt) Accept(v Visitor) {
+	if v.Visit(s) == nil {
+		return
+	}
+
+	s.ReturnExpr.Accept(v)
+}

--- a/src/quark/typeexpr.go
+++ b/src/quark/typeexpr.go
@@ -1,4 +1,4 @@
-package quark
+ package quark
 
 type (
 	//CompleteType is a quark type with no type parameters. CompleteType

--- a/src/quark/typeexpr.go
+++ b/src/quark/typeexpr.go
@@ -71,3 +71,34 @@ func (t *CompleteType) typeExprNode() {}
 func (t *ParameterizedType) typeExprNode() {}
 func (t *TypeParameter) typeExprNode() {}
 
+func (t *CompleteType) Accept(v Visitor) {
+	if v.Visit(t) == nil {
+		return
+	}
+
+	t.X.Accept(v)
+}
+
+func (t *ParameterizedType) Accept(v Visitor) {
+	if v.Visit(t) == nil {
+		return
+	}
+
+	t.BaseType.Accept(v)
+	for _, param := range t.Parameters {
+		param.Accept(v)
+	}
+}
+
+func (t *TypeParameter) Accept(v Visitor) {
+	if v.Visit(t) == nil {
+		return
+	}
+
+	if t.XType != nil {
+		t.XType.Accept(v)
+	}
+	if t.XExpr != nil {
+		t.XExpr.Accept(v)
+	}
+}

--- a/src/quark/visitor.go
+++ b/src/quark/visitor.go
@@ -1,8 +1,12 @@
 package quark
 
-
 //Visitor which can visit AST nodes.
-type ASTVisitor interface {
+type Visitor interface {
+	Visit(node AST) Visitor
+}
 
+
+//Calls visit on the visitor for the node and its children.
+func Walk(v Visitor, node AST) {
 
 }

--- a/src/quark/visitor_test.go
+++ b/src/quark/visitor_test.go
@@ -1,0 +1,50 @@
+package quark
+
+import (
+	"testing"
+)
+
+type TestASTVisitor struct {
+	count int
+}
+
+func (v *TestASTVisitor) Visit(node AST) Visitor {
+	v.count += 1
+	return v
+}
+
+func TestVisitorVisitCount(t *testing.T) {
+	var tests = []struct{
+		name string
+		in AST
+		out int
+	}{
+		{
+			"variable-decl",
+			&AssignStmt{
+				AssignTo: &VariableDefinitionAssignable{
+					IsMut:   false,
+					VarType: &CompleteType{X:&RealName{Text:"Bit"}},
+					VarName: &RealName{Text:"x"},
+					kwMut:   ObjectPosition{},
+				},
+				AssignmentType: OpAssign,
+				TheExpr:        &LiteralExpr{Value:&Literal{Text:"0"}},
+				semi:           ObjectPosition{},
+			},
+			7,
+		},
+	}
+
+	for _, test := range tests {
+		name := test.name
+		t.Run(name, func(t *testing.T) {
+			visitor := &TestASTVisitor{count: 0}
+			test.in.Accept(visitor)
+
+			if test.out != visitor.count {
+				t.Errorf("Expected %d nodes but visited %d", test.out, visitor.count)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implement a double-dispatch visitor API for walking the AST. Generally, future compiler stages should implement `quark.Visitor` to read or modify the AST.